### PR TITLE
Resolved bug: Internal failure when no. of titles exceeded 50

### DIFF
--- a/worklist/views_helper_functions/store_articles.py
+++ b/worklist/views_helper_functions/store_articles.py
@@ -55,7 +55,7 @@ def store_psid_articles(worklist_object, psid, created_by):
     if len(articles) == 0:
         return False
 
-    for article in articles['articles']:
+    for article in articles:
         data = {'article_id': article['id'], 'name': article['title']}
         article_object = Articles.create_object(data)
 

--- a/worklist/wikipedia_utils.py
+++ b/worklist/wikipedia_utils.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import math
 import mwclient
 
 
@@ -8,12 +9,17 @@ def convert_article_titles_into_ids(titles):
         return defaultdict(int)
 
     page_title_to_id_mapping = defaultdict(int)
+    titles_array = titles
+    while titles_array:
+        # Since at max 50 titles can be passed in one request
+        titles_list = ' | '.join(str(page) for page in
+                                 titles_array[:50])
 
-    titles_list = ' | '.join(str(page) for page in titles)
+        titles_array = titles_array[50:]
 
-    site = mwclient.Site('en.wikipedia.org')
-    result = site.api('query', prop='info', titles=titles_list)
-    for page in result['query']['pages'].values():
-        page_title_to_id_mapping[str(page.get('title'))] = page.get('pageid')
+        site = mwclient.Site('en.wikipedia.org')
+        result = site.api('query', prop='info', titles=titles_list)
+        for page in result['query']['pages'].values():
+            page_title_to_id_mapping[str(page.get('title'))] = page.get('pageid')
 
     return page_title_to_id_mapping


### PR DESCRIPTION
@eggpi please review.
Found this bug where mwclient failed silently by giving out a simple message in case titles exceeded 50.
