### PR TITLE
Increased timeout to 180s

### DIFF
--- a/worklist/constants.py
+++ b/worklist/constants.py
@@ -25,7 +25,10 @@ SEARCH_BY_NAME_FOR_WORKLISTS = 'worklist_name'
 SEARCH_BY_USERNAME_FOR_WORKLISTS = 'username'
 
 # Default timeout for HTTP GET Request
-TIMEOUT_IN_SECONDS = 180
+TIMEOUT_IN_SECONDS = 10
 
 # URL for Petscan
 PETSCAN_URL = "https://petscan.wmflabs.org"
+
+# Timeout for PetScan
+TIMEOUT_FOR_PETSCAN = 180

--- a/worklist/constants.py
+++ b/worklist/constants.py
@@ -25,7 +25,7 @@ SEARCH_BY_NAME_FOR_WORKLISTS = 'worklist_name'
 SEARCH_BY_USERNAME_FOR_WORKLISTS = 'username'
 
 # Default timeout for HTTP GET Request
-TIMEOUT_IN_SECONDS = 10
+TIMEOUT_IN_SECONDS = 180
 
 # URL for Petscan
 PETSCAN_URL = "https://petscan.wmflabs.org"

--- a/worklist/views.py
+++ b/worklist/views.py
@@ -103,7 +103,9 @@ def create_worklist(request):
                                               data['psid'], data['created_by'])
                 if success is False:
                     content['error'] = 1
-                    content['message'] = 'Petscan articles could not be saved.'
+                    content['message'] = 'Petscan articles could not be saved. Avoid queries that take '\
+                                        'very long for PetScan to evaluate and make sure your provided '\
+                                        'PSID is valid.'
 
         if content['error'] == 1:
             WorkList.objects.filter(name=data['name'],

--- a/worklist/views_helper_functions/fetch_articles_from_petscan.py
+++ b/worklist/views_helper_functions/fetch_articles_from_petscan.py
@@ -1,6 +1,6 @@
 import requests
 import logging
-from worklist.constants import TIMEOUT_IN_SECONDS, PETSCAN_URL
+from worklist.constants import TIMEOUT_FOR_PETSCAN, PETSCAN_URL
 
 logger = logging.getLogger('django')
 
@@ -14,7 +14,7 @@ def fetch_articles_from_petscan(psid):
     parameters = {'format': 'json', 'psid': psid}
     
     try:
-        response = requests.get(PETSCAN_URL, params=parameters, timeout=TIMEOUT_IN_SECONDS).json()
+        response = requests.get(PETSCAN_URL, params=parameters, timeout=TIMEOUT_FOR_PETSCAN).json()
     except Exception as e:
         logger.info('Failed to query PetScan: {0} {1}'.format(type(e), e))
         return articles


### PR DESCRIPTION
Since the PetScan can be slow sometimes, so queries which are still valid but takes longer time gives error because of less timeout (10s). Hence, the timeout need to be increased.

Closes issue #46 